### PR TITLE
[Refactor] official_place_id를 FK로 변경, Open API 데이터 적재 로직 수정, ConcurrentHashMap 도입

### DIFF
--- a/src/main/java/com/boombim/congestion/repository/OfficialCongestionDao.java
+++ b/src/main/java/com/boombim/congestion/repository/OfficialCongestionDao.java
@@ -25,7 +25,7 @@ public class OfficialCongestionDao {
      * @return 생성된 official_congestions 테이블의 id
      */
     public Long save(
-        String poiCode,
+        Long officialPlaceId,
         Integer congestionLevelId,
         Long populationMin,
         Long populationMax,
@@ -34,7 +34,7 @@ public class OfficialCongestionDao {
 
         String sql = """
             INSERT INTO official_congestions (
-                poi_code, congestion_level_id, population_min, population_max, observed_at
+                official_place_id, congestion_level_id, population_min, population_max, observed_at
             ) VALUES (?, ?, ?, ?, ?)
             """;
 
@@ -42,7 +42,7 @@ public class OfficialCongestionDao {
 
         jdbcTemplate.update(connection -> {
             PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
-            ps.setString(1, poiCode);
+            ps.setLong(1, officialPlaceId);
             ps.setInt(2, congestionLevelId);
             ps.setObject(3, populationMin);
             ps.setObject(4, populationMax);

--- a/src/main/java/com/boombim/congestion/repository/OfficialCongestionForecastDao.java
+++ b/src/main/java/com/boombim/congestion/repository/OfficialCongestionForecastDao.java
@@ -16,14 +16,16 @@ public class OfficialCongestionForecastDao {
      *
      * @param batchArgs 서비스 계층에서 모든 파라미터가 준비된 Object 배열 리스트
      */
-    public void saveAll(List<Object[]> batchArgs) {
+    public void saveAll(
+        List<Object[]> batchArgs
+    ) {
         if (batchArgs == null || batchArgs.isEmpty()) {
             return;
         }
 
         String sql = """
             INSERT INTO official_congestion_forecasts (
-                poi_code, observed_at, forecast_time, forecast_congestion_level_id,
+                official_place_id, observed_at, forecast_time, forecast_congestion_level_id,
                 forecast_population_min, forecast_population_max
             )
             VALUES (?, ?, ?, ?, ?, ?)

--- a/src/main/java/com/boombim/openapi/OpenApiClient.java
+++ b/src/main/java/com/boombim/openapi/OpenApiClient.java
@@ -29,8 +29,6 @@ public class OpenApiClient {
 
         for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
             try {
-                log.info("[OpenApiClient] fetch {} {}/{}", poiCode, attempt + 1, MAX_ATTEMPTS);
-
                 OpenApiResponse response = webClient.get()
                     .uri(endpoint)
                     .accept(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/boombim/openapi/service/OpenApiService.java
+++ b/src/main/java/com/boombim/openapi/service/OpenApiService.java
@@ -8,7 +8,7 @@ import com.boombim.congestion.repository.OfficialCongestionForecastDao;
 import com.boombim.openapi.OpenApiClient;
 import com.boombim.openapi.dto.OpenApiResponse;
 import com.boombim.openapi.dto.OpenApiResponse.CityDataItem;
-import com.boombim.place.repository.OfficialPlaceDao;
+import com.boombim.place.OfficialPlaceCache;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,8 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class OpenApiService {
 
     private final OpenApiClient openApiClient;
-    private final OfficialPlaceDao officialPlaceDao;
     private final CongestionLevelDao congestionLevelDao;
+    private final OfficialPlaceCache officialPlaceCache;
     private final OfficialCongestionDao officialCongestionDao;
     private final OfficialCongestionForecastDao officialCongestionForecastDao;
     private final OfficialCongestionDemographicDao officialCongestionDemographicDao;
@@ -34,10 +34,20 @@ public class OpenApiService {
     @Transactional
     public void fetchAndSave() {
 
-        // TODO: 서버 최초 실행시 조회해서 메모리에 띄워놓고 관리하는 방식으로 리팩터링
-        List<String> poiCodes = officialPlaceDao.findAllPoiCodes();
+        List<String> poiCodes = officialPlaceCache.getAllPoiCodes();
+        int fetchCount = 1;
 
         for (String poiCode : poiCodes) {
+
+            log.info("Fetch {}/{}", fetchCount++, poiCodes.size());
+
+            Long officialPlaceId = officialPlaceCache.getOfficialPlaceId(poiCode).orElse(null);
+
+            if (officialPlaceId == null) {
+                log.warn("{} - 해당하는 officialPlaceId 찾지 못함!", poiCode);
+                continue;
+            }
+
             OpenApiResponse response = openApiClient.fetch(poiCode);
             if (response == null || response.citydataPpltn() == null) {
                 log.warn("POI 코드 '{}'에 대한 API 응답이 없습니다.", poiCode);
@@ -59,7 +69,7 @@ public class OpenApiService {
                 }
 
                 Long officialCongestionId = officialCongestionDao.save(
-                    item.areaCode(),
+                    officialPlaceId,
                     congestionLevelId,
                     item.populationMinimum(),
                     item.populationMaximum(),
@@ -69,7 +79,7 @@ public class OpenApiService {
                 List<OfficialCongestionDemographicInfoDto> demographics = convertToDemographics(item);
                 officialCongestionDemographicDao.saveAll(officialCongestionId, demographics);
 
-                saveForecasts(item, poiCode);
+                saveForecasts(item, officialPlaceId);
             }
         }
     }
@@ -77,7 +87,10 @@ public class OpenApiService {
     /**
      * 예측 데이터를 저장하는 로직을 별도 메서드로 분리
      */
-    private void saveForecasts(CityDataItem item, String poiCode) {
+    private void saveForecasts(
+        CityDataItem item,
+        Long officialPlaceId
+    ) {
         if (item.forecast() == null || item.forecast().isEmpty()) {
             return;
         }
@@ -85,20 +98,19 @@ public class OpenApiService {
         List<Object[]> forecastBatchArgs = new ArrayList<>();
         for (OpenApiResponse.CityDataItem.ForecastItem forecastItem : item.forecast()) {
 
-            Integer forecastLevelId = congestionLevelDao.findIdByName(forecastItem.forecastCongestLevel())
+            Integer forecastLevelId = congestionLevelDao
+                .findIdByName(forecastItem.forecastCongestLevel())
                 .orElse(null);
 
             if (forecastLevelId != null) {
                 forecastBatchArgs.add(new Object[]{
-                    poiCode,
+                    officialPlaceId,
                     item.populationTime(),
                     forecastItem.forecastTime(),
                     forecastLevelId,
                     forecastItem.forecastPopulationMinimum(),
                     forecastItem.forecastPopulationMaximum()
                 });
-            } else {
-                log.warn("알 수 없는 예측 혼잡도 레벨 '{}' (poiCode: {}). 이 예측은 건너뜁니다.", forecastItem.forecastCongestLevel(), poiCode);
             }
         }
         officialCongestionForecastDao.saveAll(forecastBatchArgs);
@@ -107,7 +119,9 @@ public class OpenApiService {
     /**
      * Open API 응답 아이템을 인구통계 데이터 리스트로 변환하는 메서드
      */
-    private List<OfficialCongestionDemographicInfoDto> convertToDemographics(OpenApiResponse.CityDataItem item) {
+    private List<OfficialCongestionDemographicInfoDto> convertToDemographics(
+        CityDataItem item
+    ) {
         List<OfficialCongestionDemographicInfoDto> list = new ArrayList<>();
         list.add(new OfficialCongestionDemographicInfoDto("GENDER", "MALE", item.malePopulationRate()));
         list.add(new OfficialCongestionDemographicInfoDto("GENDER", "FEMALE", item.femalePopulationRate()));

--- a/src/main/java/com/boombim/place/OfficialPlaceCache.java
+++ b/src/main/java/com/boombim/place/OfficialPlaceCache.java
@@ -1,0 +1,5 @@
+package com.boombim.place;
+
+public class OfficialPlaceCache {
+
+}

--- a/src/main/java/com/boombim/place/OfficialPlaceCache.java
+++ b/src/main/java/com/boombim/place/OfficialPlaceCache.java
@@ -1,5 +1,64 @@
 package com.boombim.place;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class OfficialPlaceCache {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final Map<String, Long> poiCodeToId = new ConcurrentHashMap<>();
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void load() {
+        jdbcTemplate.query(
+            "SELECT poi_code, id FROM official_places",
+            rs -> {
+                poiCodeToId.put(rs.getString(1), rs.getLong(2));
+            }
+        );
+
+        log.info("Caching Finished");
+        log.info("poiCodeToId Size: {}", poiCodeToId.size());
+    }
+
+    public Optional<Long> getOfficialPlaceId(
+        String poiCode
+    ) {
+        Long cachedId = poiCodeToId.get(poiCode);
+
+        if (cachedId != null) {
+            return Optional.of(cachedId);
+        }
+
+        List<Long> list = jdbcTemplate.query(
+            "SELECT id FROM official_places WHERE poi_code = ?",
+            (rs, i) -> rs.getLong(1),
+            poiCode
+        );
+
+        if (list.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Long id = list.get(0);
+        poiCodeToId.put(poiCode, id);
+
+        return Optional.of(id);
+    }
+
+    public List<String> getAllPoiCodes() {
+        return List.copyOf(poiCodeToId.keySet());
+    }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #7 

## 📝작업 내용

- `official_congestions`, `official_congestion_forecasts`의 FK를 `poi_code` → `official_place_id`로 변경
- Open API 데이터 적재 로직 수정
  - DAO 레이어에서 `official_place_id`를 직접 INSERT 하도록 변경
  - `OfficialPlaceCache`를 추가하여 `poi_code → id` 매핑
  - `OpenApiService`에서 `findAllPoiCodes()` 대신 캐시 기반으로 POI 순회 및 `officialPlaceId` 조회
- DB 스키마 변경
  - FK 제약 조건 수정