### PR TITLE
[Feat] 공식 장소 저장 시 면적 계산 및 주소 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     // jts
     implementation 'org.locationtech.jts:jts-core:1.19.0'
 
+    implementation 'org.locationtech.proj4j:proj4j:1.1.0'
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/boombim/common/config/WebClientConfig.java
+++ b/src/main/java/com/boombim/common/config/WebClientConfig.java
@@ -1,10 +1,15 @@
 package com.boombim.common.config;
 
 import static com.boombim.common.constant.OpenApiConstant.*;
+import static org.springframework.http.HttpHeaders.*;
 
+import com.boombim.common.properties.KakaoProperties;
+import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 
 @Configuration
 public class WebClientConfig {
@@ -17,4 +22,17 @@ public class WebClientConfig {
             .build();
     }
 
+    @Bean
+    public WebClient kakaoWebClient(
+        KakaoProperties properties
+    ) {
+        HttpClient httpClient = HttpClient.create()
+            .responseTimeout(Duration.ofSeconds(3));
+
+        return WebClient.builder()
+            .baseUrl(properties.baseUrl())
+            .defaultHeader(AUTHORIZATION, properties.scheme() + properties.apiKey())
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .build();
+    }
 }

--- a/src/main/java/com/boombim/common/geo/AreaCalculator.java
+++ b/src/main/java/com/boombim/common/geo/AreaCalculator.java
@@ -1,5 +1,75 @@
 package com.boombim.common.geo;
 
-public class AreaCalculator {
+import java.util.ArrayList;
+import java.util.List;
+import org.locationtech.jts.geom.*;
+import org.locationtech.proj4j.*;
 
+public final class AreaCalculator {
+
+    private static final CRSFactory CRS_FACTORY = new CRSFactory();
+    private static final CoordinateTransformFactory CT_FACTORY = new CoordinateTransformFactory();
+
+    private static final CoordinateReferenceSystem WGS84 = CRS_FACTORY.createFromName("EPSG:4326");
+    private static final CoordinateReferenceSystem KOREA5179 = CRS_FACTORY.createFromName("EPSG:5179");
+
+    private static final CoordinateTransform TX_TO_5179 = CT_FACTORY.createTransform(WGS84, KOREA5179);
+    private static final CoordinateTransform TX_TO_WGS84 = CT_FACTORY.createTransform(KOREA5179, WGS84);
+
+    private static final GeometryFactory GF = new GeometryFactory();
+
+    private AreaCalculator() {
+    }
+
+    /**
+     * 경위도(lon,lat) 링 좌표 → 면적(m²)
+     */
+    public static double areaM2FromLonLatRing(List<Coordinate> ringLonLat) {
+        if (ringLonLat == null || ringLonLat.size() < 3)
+            return 0d;
+
+        Polygon poly5179 = polygon5179FromLonLatRing(ringLonLat);
+        return Math.abs(poly5179.getArea()); // m²
+    }
+
+    /**
+     * 경위도(lon,lat) 링 좌표 → 센트로이드(경위도 반환)
+     */
+    public static Coordinate centroidLonLatFromLonLatRing(List<Coordinate> ringLonLat) {
+        if (ringLonLat == null || ringLonLat.size() < 3)
+            return null;
+
+        Polygon poly5179 = polygon5179FromLonLatRing(ringLonLat);
+        Point c5179 = poly5179.getCentroid(); // meters(5179)
+
+        // 5179 → WGS84
+        ProjCoordinate in = new ProjCoordinate(c5179.getX(), c5179.getY());
+        ProjCoordinate out = new ProjCoordinate();
+        TX_TO_WGS84.transform(in, out); // out.x=lon, out.y=lat
+
+        return new Coordinate(out.x, out.y); // (lon, lat)
+    }
+
+    /**
+     * 경위도 링을 5179로 투영해 닫힌 링으로 Polygon 생성
+     */
+    private static Polygon polygon5179FromLonLatRing(List<Coordinate> ringLonLat) {
+        List<Coordinate> projected = new ArrayList<>(ringLonLat.size() + 1);
+        ProjCoordinate in = new ProjCoordinate();
+        ProjCoordinate out = new ProjCoordinate();
+
+        for (Coordinate c : ringLonLat) {
+            in.x = c.x; // lon
+            in.y = c.y; // lat
+            TX_TO_5179.transform(in, out); // meters
+            projected.add(new Coordinate(out.x, out.y));
+        }
+        // close ring
+        if (!projected.get(0).equals2D(projected.get(projected.size() - 1))) {
+            projected.add(new Coordinate(projected.get(0)));
+        }
+
+        LinearRing shell = GF.createLinearRing(projected.toArray(Coordinate[]::new));
+        return GF.createPolygon(shell, null);
+    }
 }

--- a/src/main/java/com/boombim/common/geo/AreaCalculator.java
+++ b/src/main/java/com/boombim/common/geo/AreaCalculator.java
@@ -1,0 +1,5 @@
+package com.boombim.common.geo;
+
+public class AreaCalculator {
+
+}

--- a/src/main/java/com/boombim/common/properties/KakaoProperties.java
+++ b/src/main/java/com/boombim/common/properties/KakaoProperties.java
@@ -1,0 +1,5 @@
+package com.boombim.common.properties;
+
+public record KakaoProperties() {
+
+}

--- a/src/main/java/com/boombim/common/properties/KakaoProperties.java
+++ b/src/main/java/com/boombim/common/properties/KakaoProperties.java
@@ -1,5 +1,12 @@
 package com.boombim.common.properties;
 
-public record KakaoProperties() {
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kakao")
+public record KakaoProperties(
+    String baseUrl,
+    String scheme,
+    String apiKey
+) {
 
 }

--- a/src/main/java/com/boombim/congestion/repository/OfficialCongestionDao.java
+++ b/src/main/java/com/boombim/congestion/repository/OfficialCongestionDao.java
@@ -17,12 +17,12 @@ public class OfficialCongestionDao {
     /**
      * 하나의 혼잡도 데이터를 저장하고, 자동 생성된 PK(id)를 반환
      *
-     * @param poiCode           장소 코드
+     * @param officialPlaceId   공식 장소 ID
      * @param congestionLevelId 혼잡도 수준 ID
-     * @param populationMin     최소 인구
-     * @param populationMax     최대 인구
-     * @param observedAt        관측 시각
-     * @return 생성된 official_congestions 테이블의 id
+     * @param populationMin     최소 인구 (NULL 아님)
+     * @param populationMax     최대 인구 (NULL 아님)
+     * @param observedAt        관측 시각 (NULL 아님)
+     * @return 생성된 official_congestions.id
      */
     public Long save(
         Long officialPlaceId,
@@ -32,21 +32,42 @@ public class OfficialCongestionDao {
         LocalDateTime observedAt
     ) {
 
-        String sql = """
+        final String sql = """
             INSERT INTO official_congestions (
-                official_place_id, congestion_level_id, population_min, population_max, observed_at
-            ) VALUES (?, ?, ?, ?, ?)
+                official_place_id,
+                congestion_level_id,
+                population_min,
+                population_max,
+                observed_at,
+                density_per_m2
+            )
+            SELECT
+                ?, ?, ?, ?, ?,
+                CASE
+                    WHEN op.area_m2 IS NOT NULL AND op.area_m2 > 0
+                      THEN (COALESCE(?, ?)::double precision) / op.area_m2
+                    ELSE NULL
+                END
+            FROM official_places op
+            WHERE op.id = ?
             """;
 
         KeyHolder keyHolder = new GeneratedKeyHolder();
 
-        jdbcTemplate.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
+        jdbcTemplate.update(conn -> {
+            PreparedStatement ps = conn.prepareStatement(sql, new String[]{"id"});
+
             ps.setLong(1, officialPlaceId);
             ps.setInt(2, congestionLevelId);
-            ps.setObject(3, populationMin);
-            ps.setObject(4, populationMax);
+            ps.setLong(3, populationMin);
+            ps.setLong(4, populationMax);
             ps.setObject(5, observedAt);
+
+            ps.setLong(6, populationMax);
+            ps.setLong(7, populationMin);
+
+            ps.setLong(8, officialPlaceId);
+
             return ps;
         }, keyHolder);
 
@@ -54,7 +75,6 @@ public class OfficialCongestionDao {
         if (key == null) {
             throw new IllegalStateException("Failed to retrieve generated key for official_congestions.");
         }
-
         return key.longValue();
     }
 }

--- a/src/main/java/com/boombim/openapi/OpenApiClient.java
+++ b/src/main/java/com/boombim/openapi/OpenApiClient.java
@@ -16,7 +16,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class OpenApiClient {
 
-    private final WebClient webClient;
+    private final WebClient openApiWebClient;
     private final OpenApiProperties openApiProperties;
 
     public OpenApiResponse fetch(
@@ -29,7 +29,7 @@ public class OpenApiClient {
 
         for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
             try {
-                OpenApiResponse response = webClient.get()
+                OpenApiResponse response = openApiWebClient.get()
                     .uri(endpoint)
                     .accept(MediaType.APPLICATION_JSON)
                     .exchangeToMono(clientResponse -> {

--- a/src/main/java/com/boombim/openapi/dto/KakaoRegionResponse.java
+++ b/src/main/java/com/boombim/openapi/dto/KakaoRegionResponse.java
@@ -1,0 +1,5 @@
+package com.boombim.openapi.dto;
+
+public record KakaoRegionResponse() {
+
+}

--- a/src/main/java/com/boombim/openapi/dto/KakaoRegionResponse.java
+++ b/src/main/java/com/boombim/openapi/dto/KakaoRegionResponse.java
@@ -1,5 +1,24 @@
 package com.boombim.openapi.dto;
 
-public record KakaoRegionResponse() {
+import java.util.List;
+
+public record KakaoRegionResponse(
+    List<Document> documents
+) {
+
+    /**
+     * @param region_type        H (행정동) / B (법정동)
+     * @param region_2depth_name 구
+     * @param region_3depth_name 동
+     * @param code               법정동 코드 (10자리)
+     */
+    public record Document(
+        String region_type,
+        String region_2depth_name,
+        String region_3depth_name,
+        String code
+    ) {
+
+    }
 
 }

--- a/src/main/java/com/boombim/openapi/dto/LegalDong.java
+++ b/src/main/java/com/boombim/openapi/dto/LegalDong.java
@@ -1,0 +1,5 @@
+package com.boombim.openapi.dto;
+
+public record LegalDong() {
+
+}

--- a/src/main/java/com/boombim/openapi/dto/LegalDong.java
+++ b/src/main/java/com/boombim/openapi/dto/LegalDong.java
@@ -1,5 +1,13 @@
 package com.boombim.openapi.dto;
 
-public record LegalDong() {
+public record LegalDong(
+    String gu,
+    String dong,
+    String code
+) {
+
+    public String display() {
+        return gu + " " + dong;
+    }
 
 }

--- a/src/main/java/com/boombim/openapi/service/KakaoRegionCodeService.java
+++ b/src/main/java/com/boombim/openapi/service/KakaoRegionCodeService.java
@@ -1,5 +1,44 @@
 package com.boombim.openapi.service;
 
+import com.boombim.openapi.dto.KakaoRegionResponse;
+import com.boombim.openapi.dto.LegalDong;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class KakaoRegionCodeService {
 
+    private final WebClient kakaoWebClient;
+
+    public Optional<LegalDong> getLegalDong(double lon, double lat) {
+        try {
+            var res = kakaoWebClient.get()
+                .uri(u -> u.path("/v2/local/geo/coord2regioncode.json")
+                    .queryParam("x", lon)
+                    .queryParam("y", lat)
+                    .build())
+                .retrieve()
+                .bodyToMono(KakaoRegionResponse.class)
+                .block(Duration.ofSeconds(3));
+
+            if (res == null || res.documents() == null)
+                return Optional.empty();
+
+            return res.documents().stream()
+                .filter(d -> "B".equalsIgnoreCase(d.region_type()))
+                .findFirst()
+                .map(d -> new LegalDong(d.region_2depth_name(), d.region_3depth_name(), d.code()));
+
+        } catch (Exception e) {
+            log.warn("coord2regioncode failed (lon={}, lat={}): {}", lon, lat, e.toString());
+            return Optional.empty();
+        }
+
+    }
 }

--- a/src/main/java/com/boombim/openapi/service/KakaoRegionCodeService.java
+++ b/src/main/java/com/boombim/openapi/service/KakaoRegionCodeService.java
@@ -1,0 +1,5 @@
+package com.boombim.openapi.service;
+
+public class KakaoRegionCodeService {
+
+}

--- a/src/main/java/com/boombim/place/dto/OfficialPlaceDto.java
+++ b/src/main/java/com/boombim/place/dto/OfficialPlaceDto.java
@@ -6,12 +6,13 @@ import java.util.List;
  * 공식 장소 정보를 담는 DTO 클래스
  *
  * <p>
- * Open API를 통해 받아오는 120곳의 장소 데이터를 기반으로<br>
- * 장소명, POI 코드, 중심 위도, 중심 경도, 윤곽선 좌표 목록 포함
+ * Open API를 통해 받아오는 120곳의 장소 데이터를 기반으로<br> 장소명, POI 코드, 중심 위도, 중심 경도, 윤곽선 좌표 목록 포함
  * </p>
  *
  * @param name               장소명 (ex. "강남 MICE 관광특구")
  * @param poiCode            장소 식별을 위한 POI 코드
+ * @param address            행정 구역명 (ex. "강남구 삼성동")
+ * @param areaM2             윤곽선 다각형 면적 (제곱미터)
  * @param centroidLatitude   중심의 위도 (윤곽선 다각형의 중심점 기준)
  * @param centroidLongitude  중심의 경도 (윤곽선 다각형의 중심점 기준)
  * @param polygonCoordinates 윤곽선 다각형을 구성하는 좌표 목록
@@ -19,6 +20,8 @@ import java.util.List;
 public record OfficialPlaceDto(
     String name,
     String poiCode,
+    String address,
+    double areaM2,
     double centroidLatitude,
     double centroidLongitude,
     List<List<Double>> polygonCoordinates
@@ -27,6 +30,8 @@ public record OfficialPlaceDto(
     public static OfficialPlaceDto of(
         String name,
         String poiCode,
+        String address,
+        double areaM2,
         double centroidLatitude,
         double centroidLongitude,
         List<List<Double>> polygonCoordinates
@@ -34,6 +39,8 @@ public record OfficialPlaceDto(
         return new OfficialPlaceDto(
             name,
             poiCode,
+            address,
+            areaM2,
             centroidLatitude,
             centroidLongitude,
             polygonCoordinates

--- a/src/main/java/com/boombim/place/dto/OfficialPlaceDto.java
+++ b/src/main/java/com/boombim/place/dto/OfficialPlaceDto.java
@@ -3,24 +3,24 @@ package com.boombim.place.dto;
 import java.util.List;
 
 /**
- * 공식 장소 정보를 담는 DTO 클래스
+ * 공식 장소 정보를 담는 DTO
  *
  * <p>
- * Open API를 통해 받아오는 120곳의 장소 데이터를 기반으로<br> 장소명, POI 코드, 중심 위도, 중심 경도, 윤곽선 좌표 목록 포함
+ * Open API로 수집한 120곳의 장소 데이터를 기반으로 아래 필드를 담습니다.
  * </p>
  *
- * @param name               장소명 (ex. "강남 MICE 관광특구")
+ * @param name               장소명 (예: "강남 MICE 관광특구")
  * @param poiCode            장소 식별을 위한 POI 코드
- * @param address            행정 구역명 (ex. "강남구 삼성동")
- * @param areaM2             윤곽선 다각형 면적 (제곱미터)
- * @param centroidLatitude   중심의 위도 (윤곽선 다각형의 중심점 기준)
- * @param centroidLongitude  중심의 경도 (윤곽선 다각형의 중심점 기준)
- * @param polygonCoordinates 윤곽선 다각형을 구성하는 좌표 목록
+ * @param legalDong          법정동 (예: "강남구 삼성동")
+ * @param areaM2             윤곽선 다각형 면적(㎡)
+ * @param centroidLatitude   중심 위도(다각형 센트로이드)
+ * @param centroidLongitude  중심 경도(다각형 센트로이드)
+ * @param polygonCoordinates 윤곽선 다각형 좌표(경도,위도) 목록
  */
 public record OfficialPlaceDto(
     String name,
     String poiCode,
-    String address,
+    String legalDong,
     double areaM2,
     double centroidLatitude,
     double centroidLongitude,
@@ -30,7 +30,7 @@ public record OfficialPlaceDto(
     public static OfficialPlaceDto of(
         String name,
         String poiCode,
-        String address,
+        String legalDong,
         double areaM2,
         double centroidLatitude,
         double centroidLongitude,
@@ -39,12 +39,11 @@ public record OfficialPlaceDto(
         return new OfficialPlaceDto(
             name,
             poiCode,
-            address,
+            legalDong,
             areaM2,
             centroidLatitude,
             centroidLongitude,
             polygonCoordinates
         );
     }
-
 }

--- a/src/main/java/com/boombim/place/initializer/OfficialPlaceInitializer.java
+++ b/src/main/java/com/boombim/place/initializer/OfficialPlaceInitializer.java
@@ -2,6 +2,9 @@ package com.boombim.place.initializer;
 
 import static com.boombim.common.constant.OfficialPlaceConstant.*;
 
+import com.boombim.common.geo.AreaCalculator;
+import com.boombim.openapi.dto.LegalDong;
+import com.boombim.openapi.service.KakaoRegionCodeService;
 import com.boombim.openapi.service.OfficialPlaceImageService;
 import com.boombim.place.dto.OfficialPlaceDto;
 import com.boombim.place.repository.OfficialPlaceDao;
@@ -10,16 +13,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LinearRing;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.Coordinate;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
-import org.locationtech.jts.geom.Coordinate;
 
 @Slf4j
 @Component
@@ -27,57 +27,73 @@ import org.locationtech.jts.geom.Coordinate;
 public class OfficialPlaceInitializer implements CommandLineRunner {
 
     private final ObjectMapper objectMapper;
-    private final GeometryFactory geometryFactory;
     private final OfficialPlaceDao officialPlaceDao;
     private final OfficialPlaceImageService imageService;
+    private final KakaoRegionCodeService kakaoRegionCodeService;
 
     @Override
     public void run(String... args) throws Exception {
-
         InputStream inputStream = new ClassPathResource(METADATA).getInputStream();
         JsonNode root = objectMapper.readTree(inputStream);
 
-        List<OfficialPlaceDto> result = new ArrayList<>();
+        List<OfficialPlaceDto> batch = new ArrayList<>();
 
         for (JsonNode feature : root.get(FEATURES)) {
-            JsonNode propertiesNode = feature.get(PROPERTIES);
-            JsonNode geometryNode = feature.get(GEOMETRY);
+            JsonNode props = feature.get(PROPERTIES);
+            JsonNode geom = feature.get(GEOMETRY);
 
-            String name = propertiesNode.get(AREA_NM).asText();
-            String poiCode = propertiesNode.get(AREA_CD).asText();
+            String name = props.get(AREA_NM).asText();
+            String poiCode = props.get(AREA_CD).asText();
 
-            JsonNode ringNode = geometryNode.get(COORDINATES).get(0);
+            // 외곽 링
+            JsonNode ringNode = geom.get(COORDINATES).get(0);
 
             List<List<Double>> polygonCoordinates = new ArrayList<>();
-            List<Coordinate> jtsCoordinates = new ArrayList<>();
+            List<Coordinate> ringLonLat = new ArrayList<>();
 
             for (JsonNode pair : ringNode) {
-                double longitude = pair.get(0).asDouble();
-                double latitude = pair.get(1).asDouble();
-                polygonCoordinates.add(List.of(longitude, latitude));
-                jtsCoordinates.add(new Coordinate(longitude, latitude));
+                double lon = pair.get(0).asDouble();
+                double lat = pair.get(1).asDouble();
+                polygonCoordinates.add(List.of(lon, lat));
+                ringLonLat.add(new Coordinate(lon, lat)); // (lon, lat)
             }
 
-            LinearRing linearRing = geometryFactory
-                .createLinearRing(jtsCoordinates.toArray(new Coordinate[0]));
-            Polygon polygon = geometryFactory.createPolygon(linearRing, null);
+            // 면적(m²)
+            double areaM2 = AreaCalculator.areaM2FromLonLatRing(ringLonLat);
+            if (areaM2 <= 0) {
+                log.warn("Invalid polygon area. Skip poiCode={}, name={}", poiCode, name);
+                continue;
+            }
 
-            Point centroid = polygon.getCentroid();
-            double centroidLatitude = centroid.getY();
-            double centroidLongitude = centroid.getX();
+            // 센트로이드(경위도)
+            Coordinate centerLonLat = AreaCalculator.centroidLonLatFromLonLatRing(ringLonLat);
+            if (centerLonLat == null) {
+                log.warn("Centroid null. Skip poiCode={}, name={}", poiCode, name);
+                continue;
+            }
+            double centroidLon = centerLonLat.x;
+            double centroidLat = centerLonLat.y;
 
-            result.add(OfficialPlaceDto.of(
+            // 주소(법정동) 역지오코딩
+            Optional<LegalDong> legal = kakaoRegionCodeService.getLegalDong(centroidLon, centroidLat);
+            String address = legal.map(LegalDong::display).orElse("알수없음");
+
+            batch.add(OfficialPlaceDto.of(
                 name,
                 poiCode,
-                centroidLatitude,
-                centroidLongitude,
+                address,
+                areaM2,
+                centroidLat,
+                centroidLon,
                 polygonCoordinates
             ));
         }
 
-        officialPlaceDao.initialize(result);
-        log.info("{} official places inserted.", result.size());
+        // upsert
+        officialPlaceDao.initialize(batch);
+        log.info("{} official places upserted.", batch.size());
 
+        // 이미지 동기화
         imageService.syncAll();
         log.info("Official place images synced.");
     }

--- a/src/main/java/com/boombim/place/initializer/OfficialPlaceInitializer.java
+++ b/src/main/java/com/boombim/place/initializer/OfficialPlaceInitializer.java
@@ -74,14 +74,14 @@ public class OfficialPlaceInitializer implements CommandLineRunner {
             double centroidLon = centerLonLat.x;
             double centroidLat = centerLonLat.y;
 
-            // 주소(법정동) 역지오코딩
-            Optional<LegalDong> legal = kakaoRegionCodeService.getLegalDong(centroidLon, centroidLat);
-            String address = legal.map(LegalDong::display).orElse("알수없음");
+            // 법정동 역지오코딩
+            Optional<LegalDong> legalDongOpt = kakaoRegionCodeService.getLegalDong(centroidLon, centroidLat);
+            String legalDong = legalDongOpt.map(LegalDong::display).orElse("알수없음");
 
             batch.add(OfficialPlaceDto.of(
                 name,
                 poiCode,
-                address,
+                legalDong,
                 areaM2,
                 centroidLat,
                 centroidLon,

--- a/src/main/java/com/boombim/place/repository/OfficialPlaceDao.java
+++ b/src/main/java/com/boombim/place/repository/OfficialPlaceDao.java
@@ -15,34 +15,38 @@ public class OfficialPlaceDao {
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
 
-    public void initialize(
-        List<OfficialPlaceDto> officialPlaces
-    ) {
+    public void initialize(List<OfficialPlaceDto> officialPlaces) {
 
+        // address, area_m2 포함 + 충돌 시 갱신
         String sql = """
-                INSERT INTO official_places (name, poi_code, centroid_latitude, centroid_longitude, polygon_coordinates)
-                VALUES (?, ?, ?, ?, ?::jsonb)
-                ON CONFLICT (poi_code) DO NOTHING
+            INSERT INTO official_places
+              (name, poi_code, address, centroid_latitude, centroid_longitude, polygon_coordinates, area_m2)
+            VALUES (?, ?, ?, ?, ?, ?::jsonb, ?)
+            ON CONFLICT (poi_code) DO UPDATE
+            SET name                = EXCLUDED.name,
+                address             = EXCLUDED.address,
+                centroid_latitude   = EXCLUDED.centroid_latitude,
+                centroid_longitude  = EXCLUDED.centroid_longitude,
+                polygon_coordinates = EXCLUDED.polygon_coordinates,
+                area_m2             = EXCLUDED.area_m2
             """;
 
         List<Object[]> batchArgs = officialPlaces.stream()
-            .map(officialPlace -> {
+            .map(p -> {
                 try {
-                    String json = objectMapper
-                        .writeValueAsString(officialPlace.polygonCoordinates());
-
+                    String json = objectMapper.writeValueAsString(p.polygonCoordinates());
                     return new Object[]{
-                        officialPlace.name(),
-                        officialPlace.poiCode(),
-                        officialPlace.centroidLatitude(),
-                        officialPlace.centroidLongitude(),
-                        json
+                        p.name(),
+                        p.poiCode(),
+                        p.address(),            // 반드시 non-null (ex. "알수없음")
+                        p.centroidLatitude(),
+                        p.centroidLongitude(),
+                        json,                   // jsonb 캐스팅은 SQL에서
+                        p.areaM2()              // NOT NULL 컬럼이면 0보다 큰 값
                     };
-
                 } catch (JsonProcessingException e) {
                     throw new RuntimeException("좌표 직렬화 실패", e);
                 }
-
             }).toList();
 
         jdbcTemplate.batchUpdate(sql, batchArgs);
@@ -54,5 +58,4 @@ public class OfficialPlaceDao {
             String.class
         );
     }
-
 }

--- a/src/main/java/com/boombim/place/repository/OfficialPlaceDao.java
+++ b/src/main/java/com/boombim/place/repository/OfficialPlaceDao.java
@@ -17,18 +17,18 @@ public class OfficialPlaceDao {
 
     public void initialize(List<OfficialPlaceDto> officialPlaces) {
 
-        // address, area_m2 포함 + 충돌 시 갱신
+        // legal_dong, area_m2 포함 + 충돌 시 갱신
         String sql = """
             INSERT INTO official_places
-              (name, poi_code, address, centroid_latitude, centroid_longitude, polygon_coordinates, area_m2)
-            VALUES (?, ?, ?, ?, ?, ?::jsonb, ?)
+              (name, poi_code, legal_dong, area_m2, centroid_latitude, centroid_longitude, polygon_coordinates)
+            VALUES (?, ?, ?, ?, ?, ?, ?::jsonb)
             ON CONFLICT (poi_code) DO UPDATE
             SET name                = EXCLUDED.name,
-                address             = EXCLUDED.address,
+                legal_dong          = EXCLUDED.legal_dong,
+                area_m2             = EXCLUDED.area_m2,
                 centroid_latitude   = EXCLUDED.centroid_latitude,
                 centroid_longitude  = EXCLUDED.centroid_longitude,
-                polygon_coordinates = EXCLUDED.polygon_coordinates,
-                area_m2             = EXCLUDED.area_m2
+                polygon_coordinates = EXCLUDED.polygon_coordinates
             """;
 
         List<Object[]> batchArgs = officialPlaces.stream()
@@ -38,11 +38,11 @@ public class OfficialPlaceDao {
                     return new Object[]{
                         p.name(),
                         p.poiCode(),
-                        p.address(),            // 반드시 non-null (ex. "알수없음")
+                        p.legalDong(),          // 반드시 non-null (예: "알수없음")
+                        p.areaM2(),             // NOT NULL 권장
                         p.centroidLatitude(),
                         p.centroidLongitude(),
-                        json,                   // jsonb 캐스팅은 SQL에서
-                        p.areaM2()              // NOT NULL 컬럼이면 0보다 큰 값
+                        json                    // jsonb 캐스팅은 SQL에서
                     };
                 } catch (JsonProcessingException e) {
                     throw new RuntimeException("좌표 직렬화 실패", e);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,3 +19,8 @@ s3:
   secret-key: ${S3_SECRET_KEY}
   base-url: ${S3_BASE_URL}
   placeholder-key: ${S3_PLACEHOLDER_KEY}
+
+kakao:
+  base-url: https://dapi.kakao.com
+  scheme: "KakaoAK "
+  api-key: ${KAKAO_COORDINATE_TO_REGION_CODE_API_KEY}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #12 

## 📝작업 내용

- 공식 장소들의 중앙 좌표를 계산해서 카카오 API를 사용하여 법정동을 저장
- 공식 혼잡도를 fetch 할 때마다 `최대 추정 인구 수 / 공식 장소의 면적`을 계산하여 `official_congestions` 테이블의 `density_per_m2` 컬럼에 저장